### PR TITLE
fix macos and windows builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,26 +1,9 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
-
-from bincrafters import build_template_default, build_shared
-import platform
-import os
+from bincrafters import build_template_default
 
 if __name__ == "__main__":
 
     builder = build_template_default.get_builder(pure_c=True)
-
-    for settings, options, env_vars, build_requires, reference in builder.items:
-        installers = ["yasm_installer/1.3.0@bincrafters/stable"]
-        if build_shared.get_os() == "Windows":
-            installers.append("mingw_installer/1.0@conan/stable")
-        build_requires.update({"*": installers})
-
-    items = []
-    for item in builder.items:
-        # do not use windows shared builds
-        if not (item.settings["compiler"] == "Visual Studio" and item.options.get("libvpx:shared", False)):
-            items.append(item)
-    builder.items = items
 
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -142,7 +142,7 @@ class LibVPXConan(ConanFile):
         build_compiler = str(self.settings.compiler)
         if build_compiler == 'Visual Studio':
             compiler = 'vs' + str(self.settings.compiler.version)
-        elif build_compiler in ['gcc', 'clang']:
+        elif build_compiler in ['gcc', 'clang', 'apple-clang']:
             compiler = 'gcc'
         else:
             raise ConanInvalidConfiguration("Unsupported compiler '{}'.".format(build_compiler))

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,8 +33,8 @@ class LibVPXConan(ConanFile):
 
     def build_requirements(self):
         self.build_requires('yasm/1.3.0')
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
-            self.build_requires("msys2/20161025")
+        if tools.os_info.is_windows and "CYGWIN" not in os.environ:
+            self.build_requires("cygwin_installer/2.9.0@bincrafters/stable")
 
     def source(self):
         source_url = "https://github.com/webmproject/libvpx/archive/v%s.tar.gz" % self.version


### PR DESCRIPTION
I am not 100% sure I made the good choice here, because I don't understand why build.py was in this state, and why msys2 was required ([Upstream explicitly mentions Cygwin](https://chromium.googlesource.com/webm/libvpx/+/refs/heads/master/README#13) and [build does not seem to pass with msys2](https://ci.appveyor.com/project/bincrafters/conan-libvpx/builds/29386642))
@SSE4 @madebr @akemimadoka what do you think ?